### PR TITLE
Explain in the docs, how to assign a status to a booking.

### DIFF
--- a/content/reference/changelog.md
+++ b/content/reference/changelog.md
@@ -6,6 +6,9 @@ We're still in the process of building the API. While the technical parts
 (authorization, JSON support etc.) are mostly done, not all resources
 are complete or even available.
 
+## 2014-11-28
+  * [improvement] Explain `bookings` status assignment on creation. Update example request.
+
 ## 2014-11-24
   * [update] Describe how to use the refresh token to get a new access token in the [Testing Authorization](/reference/testing_authorization) guide.
 

--- a/content/reference/endpoints/bookings.md
+++ b/content/reference/endpoints/bookings.md
@@ -178,6 +178,11 @@ GET /bookings/:booking_id
 
 ## Create a new booking
 
+<div class="callout callout-info" markdown="1">
+  <h4>Status assignment</h4>
+  To assign a status to a booking, you have to set either `booked`, `unavailable` or `tentative_expires_at` fields. Only one of those attributes can be used at the same time.
+</div>
+
 Creates a booking for given rental.
 
 ~~~~

--- a/responses/bookings/request.json
+++ b/responses/bookings/request.json
@@ -1,6 +1,7 @@
 {
   "bookings": [
     {
+      "booked": true,
       "client_id": 37,
       "adults": 5,
       "currency": "USD",


### PR DESCRIPTION
Explain that setting booked, unavailable or tentative_expires_at will set the status and only one of those can be used.
