### PR TITLE
add footer with apisupport email

### DIFF
--- a/content/assets/stylesheets/_footer.scss
+++ b/content/assets/stylesheets/_footer.scss
@@ -1,0 +1,12 @@
+footer {
+  background-color: #2E2F3A;
+  h2 {
+    color: rgba(255, 255, 255, 0.9);
+  }
+  .container {
+    padding: 1.25em 4.25em;
+  }
+  a {
+    color: #919595;
+  }
+}

--- a/content/assets/stylesheets/application.scss
+++ b/content/assets/stylesheets/application.scss
@@ -9,3 +9,4 @@
 @import "jumbotron";
 @import "navbar";
 @import "panels";
+@import "footer";

--- a/layouts/footer.html
+++ b/layouts/footer.html
@@ -1,0 +1,12 @@
+<footer id="footer">
+  <div class="container">
+    <div class="row">
+      <div class="col-sm-6">
+        <h2>Questions?</h4>
+        <p>
+          <a href="mailto:apisupport@bookingsync.com">Ask our API support team</a>
+        </p>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/layouts/guides.html
+++ b/layouts/guides.html
@@ -25,5 +25,6 @@
       </div>
     </div>
   </div>
+  <%= render 'footer' %>
 </div>
 <%= render 'foot' %>

--- a/layouts/reference.html
+++ b/layouts/reference.html
@@ -120,5 +120,6 @@
       </div>
     </div>
   </div>
+  <%= render 'footer' %>
 </div>
 <%= render 'foot' %>


### PR DESCRIPTION
I think we should have info how to contact us. Design may be a bit retarded though
<img width="990" alt="screen shot 2017-05-24 at 13 42 06" src="https://cloud.githubusercontent.com/assets/6774970/26401567/dd18292c-4086-11e7-9c0f-a1e9d318e595.png">
