### PR TITLE
add link to Channel API

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -10,5 +10,8 @@
     <p class="text-center">
       <a href="/reference" class="btn btn-outline-white btn-xl">Read the API Reference</a>
     </p>
+    <p class="text-center">
+      <a href="https://demo.platforms.bookingsync.com/api-docs/index.html" class="btn btn-outline-white btn-xl">Read Channel API Reference for OTA connection</a>
+    </p>
   </div>
 </div>


### PR DESCRIPTION
## Context

Some partners were googling for Channel API docs and what they found was API v3 docs leading them to be super confused. So it would be a good idea to have a link for disambiguation.

That's what it looks like: https://a.cl.ly/8Lu1EqBZ